### PR TITLE
Add from ES conversion tests

### DIFF
--- a/translator/es_to_protobuff.py
+++ b/translator/es_to_protobuff.py
@@ -1,14 +1,20 @@
 from typing import Dict, Optional, List
 
+import json
 from enum import Enum
 from abc import abstractmethod, ABC
 from unittest import TestCase
-from types import SimpleNamespace
 from textwrap import indent
 
 
 MAX_ROWS = 10000
 INDENT = "  "
+
+ARROW_PARTITIONS = [
+    "file:///data/part-00000-2d5ce851-c379-4eab-94ba-1e51f996109b-c000.zstd.arrow",
+    "file:///data/part-00001-2d5ce851-c379-4eab-94ba-1e51f996109b-c000.zstd.arrow",
+    "file:///data/part-00002-2d5ce851-c379-4eab-94ba-1e51f996109b-c000.zstd.arrow",
+]
 
 
 class ExpressionType(Enum):
@@ -24,6 +30,26 @@ class Expression(ABC):
     @abstractmethod
     def to_protobuff(self) -> str:
         pass
+
+    def to_output_query(self, columns: List[str], arrow_urls: List[str]) -> str:
+
+        headers = []
+        # arrow links
+        headers.extend(f'arrow_urls: "{url}"' for url in arrow_urls)
+
+        # fields to select
+        headers.extend(f'projection_columns: "{col}"' for col in columns)
+        str_headers = "\n".join(headers)
+
+        return f"""\
+{str_headers}
+
+filter_expression {{
+{indent(self.to_protobuff(), INDENT)}
+}}
+
+max_rows: {MAX_ROWS}
+"""
 
 
 class Column(Expression):
@@ -58,24 +84,37 @@ class Literal(Expression):
             return "bool_value"
 
     def to_protobuff(self) -> str:
+        literal_value = self.literal
+        if self.type == "string_value":
+            escaped = literal_value.replace('"', '\\"')
+            literal_value = f'"{escaped}"'
+
         return f"""\
 literal {{
-{INDENT}{self.type}: {self.literal}
+{INDENT}{self.type}: {literal_value}
 }}"""
 
 
 class Call(Expression):
     def __init__(
-        self, function_name: str, arguments: List[Expression], options: List[str] = None
+        self,
+        function_name: str,
+        arguments: List[Expression],
+        options: Dict[str, Dict[str, str]] = None,
     ):
+        if not isinstance(arguments, list):
+            raise ValueError(
+                f"Expected arguments to be a list, received: {type(arguments)}"
+            )
+
+        if options is not None and not isinstance(options, dict):
+            raise ValueError(f"Expected options to be dict, received {type(options)}")
+
         self.function_name = function_name
         self.arguments = arguments
-        self.options = options or []
+        self.options = options or {}
 
     def to_protobuff(self) -> str:
-
-        if self.options:
-            raise NotImplementedError(self.to_protobuff)
 
         _str_arguments = "\n".join(
             f"""\
@@ -85,46 +124,32 @@ arguments {{
             for a in self.arguments
         )
 
-        return f"""\
-call {{
-{INDENT}function_name: "{self.function_name}"
+        internals = [f'function_name: "{self.function_name}"', _str_arguments]
 
-{indent(_str_arguments, INDENT)}
-}}"""
+        if self.options:
+            for k, d in self.options.items():
+                inner = "\n".join(f'{kk}: "{vv}"' for kk, vv in d.items())
+                internals.append(f"{k} {{\n{indent(inner, INDENT)}\n}}")
+
+        str_internals = indent("\n".join(internals), INDENT)
+        return f"call {{\n{str_internals}\n}}"
 
 
-def main_input(es: Dict):
-    est = SimpleNamespace(**es)
+def main_input(es: Dict) -> str:
 
-    sort = est.sort
-    skip = getattr(est, "from")
-    size = est.size
-    fields = est._source
+    fields = es.get("_source")
+    fields = ["xpos", "variantId"]
 
-    _str_arrow_urls = ""
-    _str_columns = "\n".join(f'projection_columns: "{col}"' for col in fields)
+    expr = unwrap_query(es["query"])
 
-    _str_where = unwrap_query(est.query)
-
-    _query = f"""\
-{_str_arrow_urls}
-{_str_columns}
-filter_expression {{
-{indent(_str_where.to_protobuff(), INDENT)}
-}}
-
-max_rows: {MAX_ROWS}
-"""
-    print(_query)
+    _query = expr.to_output_query(columns=fields, arrow_urls=ARROW_PARTITIONS)
     return _query
-
-
 
 
 def unwrap_query(query) -> Expression:
     if "bool" not in query or len(query) > 1:
         invalid_keys = ", ".join(q for q in query if q != "bool")
-        raise NotImplemented(f"Can't support invalid keys: {invalid_keys}")
+        raise NotImplementedError(f"Can't support invalid keys: {invalid_keys}")
 
     return handle_generic_query(query["bool"])
 
@@ -133,35 +158,44 @@ def b(el: str):
     return f"({el})"
 
 
+def split_into_calls_of_two(function_name: str, iterable: List[Expression]):
+    if len(iterable) == 0:
+        return None
+    if len(iterable) == 1:
+        return iterable[0]
+
+    call = Call(function_name=function_name, arguments=iterable[-2:])
+    for i in range(len(iterable) - 2, 0, -1):
+        call = Call(function_name=function_name, arguments=[iterable[i], call])
+
+    return call
+
+
 def handle_generic_query(query):
     if isinstance(query, list):
         raise ValueError(f"Can't handle list {query}")
 
     if isinstance(query, (str, int, float, bool)):
-        raise ValueError(f"Expected dictionary, received: {query}")
+        return Literal(literal=query, literal_type=None)
 
     if "bool" in query:
         return handle_generic_query(query["bool"])
 
-    terms = []
-
-    keys = ", ".join(query.keys())
-
+    terms: List[Expression] = []
+    if "field" in query:
+        terms.append(Column(query["field"]))
     if "should" in query:
         should = query["should"]
-        inner = map(handle_generic_query, should)
-        if len(should) > 1:
-            terms.append(" OR ".join(map(b, inner)))
-        else:
-            terms.append(next(inner))
+        inner = list(map(handle_generic_query, should))
+        unwrapped_should = split_into_calls_of_two("or", inner)
+        if unwrapped_should:
+            terms.append(unwrapped_should)
     if "must_not" in query:
         must_not = query["must_not"]
-        inner = map(handle_generic_query, must_not)
-        if len(must_not) > 1:
-            inner_str = " AND ".join(inner)
-        else:
-            inner_str = next(inner)
-        terms.append(f"NOT {inner_str}")
+        unwrapped_must_not = split_into_calls_of_two(
+            "and", list(map(handle_generic_query, must_not))
+        )
+        terms.append(Call("invert", arguments=[unwrapped_must_not]))
     if "filter" in query:
         filters = query["filter"]
         terms.extend(map(handle_generic_query, filters))
@@ -193,32 +227,37 @@ def handle_generic_query(query):
     if len(terms) == 1:
         return terms[0]
     if len(terms) > 1:
-        return " AND ".join(map(b, terms))
+        return split_into_calls_of_two("and", terms)
 
     # raise NotImplementedError(f'Unhandled keys {keys}')
 
 
-def handle_range(query):
+def handle_range(query) -> Expression:
     statements = []
     for field, inner in query.items():
         op_map = {
-            "lt": "<",
-            "lte": "<=",
-            "gt": ">",
-            "gte": ">=",
+            "lt": "less",
+            "lte": "less_equal",
+            "gt": "greater",
+            "gte": "greater_equal",
         }
+        f = Column(name=field)
         for op in op_map:
             if op in inner:
-                statements.append(f"{field} {op_map[op]} {inner[op]}")
+                statements.append(
+                    Call(
+                        function_name=op_map[op],
+                        arguments=[f, handle_generic_query(inner[op])],
+                    )
+                )
+                # statements.append(f"{field} {op_map[op]} {inner[op]}")
 
-    if len(statements) > 1:
-        return " AND ".join(map(b, statements))
-    return statements[0]
+    return split_into_calls_of_two("and", statements)
 
 
-def handle_exists(exists):
-    field = exists["field"]
-    return f"{field} IS NOT NULL"
+def handle_exists(exists) -> Expression:
+    field = handle_generic_query(exists)
+    return Call("is_valid", arguments=[field])
 
 
 def quote_value(value):
@@ -230,25 +269,23 @@ def quote_value(value):
 
 def handle_terms(field, value):
     if isinstance(value, list):
-        prepped_values = ", ".join(map(quote_value, value))
-        return f"{field} in ({prepped_values})"
 
-    return f"{field}={quote_value(value)}"
+        prepped_values = ", ".join(map(quote_value, value))
+        raise NotImplementedError(f"{field} in ({prepped_values})")
+
+    return Call(
+        "string_list_contains_any",
+        arguments=[Column(name=field)],
+        options={"set_lookup_options": {"values": value}},
+    )
+    # return f"{field}={quote_value(value)}"
 
 
 def handle_match(field, value):
-    return f"{field} like '%{value}%'"
-
-
-class ProtobuffStrTests(TestCase):
-    def test_example_query(self):
-        expression = Call(
-            "less",
-            arguments=[Column("gnomad_exomes_AF"), Literal(0.0001, "float_value")],
-        )
-        val = expression.to_protobuff()
-        print(val)
-
-
-if __name__ == "__main__":
-    ProtobuffStrTests().test_example_query()
+    # return f"{field} like '%{value}%'"
+    # might be something simpler here
+    return Call(
+        "match_substring_regex",
+        arguments=[handle_generic_query(field)],
+        options=[f"pattern = .+{value}.+"],
+    )

--- a/translator/es_to_protobuff.py
+++ b/translator/es_to_protobuff.py
@@ -1,0 +1,254 @@
+from typing import Dict, Optional, List
+
+from enum import Enum
+from abc import abstractmethod, ABC
+from unittest import TestCase
+from types import SimpleNamespace
+from textwrap import indent
+
+
+MAX_ROWS = 10000
+INDENT = "  "
+
+
+class ExpressionType(Enum):
+    COLUMN = 1
+    LITERAL = 2
+    CALL = 3
+
+
+class Expression(ABC):
+    def __init__(self, _type: ExpressionType) -> None:
+        self.type = _type
+
+    @abstractmethod
+    def to_protobuff(self) -> str:
+        pass
+
+
+class Column(Expression):
+    def __init__(self, name: str):
+        super().__init__(ExpressionType.COLUMN)
+        self.name = name
+
+    def to_protobuff(self) -> str:
+        return f'column: "{self.name}"'
+
+
+class Literal(Expression):
+    def __init__(self, literal: any, literal_type: Optional[str]):
+        super().__init__(ExpressionType.LITERAL)
+        self.literal = literal
+        self.type = literal_type or self.infer_type(literal)
+
+    @staticmethod
+    def infer_type(literal: any):
+        if isinstance(literal, str):
+            return "string_value"
+        if isinstance(literal, int):
+            # 32 bit: https://stackoverflow.com/a/49049072
+            if abs(literal) <= 0xFFFFFFFF:
+                return "int32_value"
+            return "int64_value"
+        if isinstance(literal, float):
+            # python 'float' is dependent on system, but is usually 64 bits
+            # import sys,math; print(sys.float_info.mant_dig + math.ceil(math.log2(sys.float_info.max_10_exp - sys.float_info.min_10_exp)) + 1)
+            return "double_value"
+        if isinstance(literal, bool):
+            return "bool_value"
+
+    def to_protobuff(self) -> str:
+        return f"""\
+literal {{
+{INDENT}{self.type}: {self.literal}
+}}"""
+
+
+class Call(Expression):
+    def __init__(
+        self, function_name: str, arguments: List[Expression], options: List[str] = None
+    ):
+        self.function_name = function_name
+        self.arguments = arguments
+        self.options = options or []
+
+    def to_protobuff(self) -> str:
+
+        if self.options:
+            raise NotImplementedError(self.to_protobuff)
+
+        _str_arguments = "\n".join(
+            f"""\
+arguments {{
+{indent(a.to_protobuff(), INDENT)}
+}}"""
+            for a in self.arguments
+        )
+
+        return f"""\
+call {{
+{INDENT}function_name: "{self.function_name}"
+
+{indent(_str_arguments, INDENT)}
+}}"""
+
+
+def main_input(es: Dict):
+    est = SimpleNamespace(**es)
+
+    sort = est.sort
+    skip = getattr(est, "from")
+    size = est.size
+    fields = est._source
+
+    _str_arrow_urls = ""
+    _str_columns = "\n".join(f'projection_columns: "{col}"' for col in fields)
+
+    _str_where = unwrap_query(est.query)
+
+    _query = f"""\
+{_str_arrow_urls}
+{_str_columns}
+filter_expression {{
+{indent(_str_where.to_protobuff(), INDENT)}
+}}
+
+max_rows: {MAX_ROWS}
+"""
+    print(_query)
+    return _query
+
+
+
+
+def unwrap_query(query) -> Expression:
+    if "bool" not in query or len(query) > 1:
+        invalid_keys = ", ".join(q for q in query if q != "bool")
+        raise NotImplemented(f"Can't support invalid keys: {invalid_keys}")
+
+    return handle_generic_query(query["bool"])
+
+
+def b(el: str):
+    return f"({el})"
+
+
+def handle_generic_query(query):
+    if isinstance(query, list):
+        raise ValueError(f"Can't handle list {query}")
+
+    if isinstance(query, (str, int, float, bool)):
+        raise ValueError(f"Expected dictionary, received: {query}")
+
+    if "bool" in query:
+        return handle_generic_query(query["bool"])
+
+    terms = []
+
+    keys = ", ".join(query.keys())
+
+    if "should" in query:
+        should = query["should"]
+        inner = map(handle_generic_query, should)
+        if len(should) > 1:
+            terms.append(" OR ".join(map(b, inner)))
+        else:
+            terms.append(next(inner))
+    if "must_not" in query:
+        must_not = query["must_not"]
+        inner = map(handle_generic_query, must_not)
+        if len(must_not) > 1:
+            inner_str = " AND ".join(inner)
+        else:
+            inner_str = next(inner)
+        terms.append(f"NOT {inner_str}")
+    if "filter" in query:
+        filters = query["filter"]
+        terms.extend(map(handle_generic_query, filters))
+
+    if "must" in query:
+        filters = query["must"]
+        terms.extend(map(handle_generic_query, filters))
+
+    if "range" in query:
+        terms.append(handle_range(query["range"]))
+
+    if "exists" in query:
+        terms.append(handle_exists(query["exists"]))
+
+    if "terms" in query:
+        for field, value in query["terms"].items():
+            terms.append(handle_terms(field, value))
+
+    if "term" in query:
+        for field, value in query["term"].items():
+            terms.append(handle_terms(field, value))
+
+    if "match" in query:
+        for field, value in query["match"].items():
+            terms.append(handle_match(field, value))
+
+    if len(terms) == 0:
+        raise ValueError("Not enough terms")
+    if len(terms) == 1:
+        return terms[0]
+    if len(terms) > 1:
+        return " AND ".join(map(b, terms))
+
+    # raise NotImplementedError(f'Unhandled keys {keys}')
+
+
+def handle_range(query):
+    statements = []
+    for field, inner in query.items():
+        op_map = {
+            "lt": "<",
+            "lte": "<=",
+            "gt": ">",
+            "gte": ">=",
+        }
+        for op in op_map:
+            if op in inner:
+                statements.append(f"{field} {op_map[op]} {inner[op]}")
+
+    if len(statements) > 1:
+        return " AND ".join(map(b, statements))
+    return statements[0]
+
+
+def handle_exists(exists):
+    field = exists["field"]
+    return f"{field} IS NOT NULL"
+
+
+def quote_value(value):
+    if isinstance(value, str):
+        escaped = value.replace("'", "\\'")
+        return f"'{escaped}'"
+    return value
+
+
+def handle_terms(field, value):
+    if isinstance(value, list):
+        prepped_values = ", ".join(map(quote_value, value))
+        return f"{field} in ({prepped_values})"
+
+    return f"{field}={quote_value(value)}"
+
+
+def handle_match(field, value):
+    return f"{field} like '%{value}%'"
+
+
+class ProtobuffStrTests(TestCase):
+    def test_example_query(self):
+        expression = Call(
+            "less",
+            arguments=[Column("gnomad_exomes_AF"), Literal(0.0001, "float_value")],
+        )
+        val = expression.to_protobuff()
+        print(val)
+
+
+if __name__ == "__main__":
+    ProtobuffStrTests().test_example_query()

--- a/translator/es_to_protobuff_test.py
+++ b/translator/es_to_protobuff_test.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+
+from es_to_protobuff import *
+
+ARROW_PARTITIONS = [
+    "file:///data/part-00000-2d5ce851-c379-4eab-94ba-1e51f996109b-c000.zstd.arrow",
+    "file:///data/part-00001-2d5ce851-c379-4eab-94ba-1e51f996109b-c000.zstd.arrow",
+    "file:///data/part-00002-2d5ce851-c379-4eab-94ba-1e51f996109b-c000.zstd.arrow",
+]
+
+
+class ProtobuffStrTests(TestCase):
+    def test_example_query(self):
+        expression = Call(
+            "less",
+            arguments=[Column("gnomad_exomes_AF"), Literal(0.0001, "float_value")],
+        )
+        val = expression.to_output_query(
+            columns=["xpos", "variantId"], arrow_urls=ARROW_PARTITIONS
+        )
+
+        print(val)
+
+    def test_loaded_query(self):
+        file = "translator/more-complex-query.json"
+        with open(file) as f:
+            d = json.load(f)
+        print(main_input(d))
+
+    def test_na12878_not_benign_query(self):
+        file = "translator/query_na12878.json"
+        with open(file) as f:
+            d = json.load(f)
+        print(main_input(d))

--- a/translator/es_to_sql.py
+++ b/translator/es_to_sql.py
@@ -1,0 +1,154 @@
+from typing import Dict
+
+from types import SimpleNamespace
+
+
+def main_input(es: Dict):
+    est = SimpleNamespace(**es)
+
+    sort = est.sort
+    skip = getattr(est, "from")
+    size = est.size
+    fields = est._source
+
+    _str_fields = "*"  # '", ".join(fields)
+    _str_sortby = ""
+    _str_skip = ""
+    _str_limit = ""
+    if sort:
+        _str_sortby = f'ORDER BY {", ".join(sort)}'
+
+    if skip:
+        _str_skip = f"SKIP {skip}"
+    if size is not None:
+        _str_limit = f"LIMIT {size}"
+
+    _str_where = unwrap_query(est.query)
+
+    _query = f"""
+SELECT {_str_fields} 
+FROM table 
+WHERE {_str_where}
+{_str_sortby}
+{_str_skip} {_str_limit}
+"""
+    print(_query)
+
+
+def unwrap_query(query):
+    if "bool" not in query or len(query) > 1:
+        invalid_keys = ", ".join(q for q in query if q != "bool")
+        raise NotImplemented(f"Can't support invalid keys: {invalid_keys}")
+
+    return handle_generic_query(query["bool"])
+
+
+def b(el: str):
+    return f"({el})"
+
+
+def handle_generic_query(query):
+    if isinstance(query, list):
+        raise ValueError(f"Can't handle list {query}")
+
+    if isinstance(query, (str, int, float, bool)):
+        raise ValueError(f"Expected dictionary, received: {query}")
+
+    if "bool" in query:
+        return handle_generic_query(query["bool"])
+
+    terms = []
+
+    keys = ", ".join(query.keys())
+
+    if "should" in query:
+        should = query["should"]
+        inner = map(handle_generic_query, should)
+        if len(should) > 1:
+            terms.append(" OR ".join(map(b, inner)))
+        else:
+            terms.append(next(inner))
+    if "must_not" in query:
+        must_not = query["must_not"]
+        inner = map(handle_generic_query, must_not)
+        if len(must_not) > 1:
+            inner_str = " AND ".join(inner)
+        else:
+            inner_str = next(inner)
+        terms.append(f"NOT {inner_str}")
+    if "filter" in query:
+        filters = query["filter"]
+        terms.extend(map(handle_generic_query, filters))
+
+    if "must" in query:
+        filters = query["must"]
+        terms.extend(map(handle_generic_query, filters))
+
+    if "range" in query:
+        terms.append(handle_range(query["range"]))
+
+    if "exists" in query:
+        terms.append(handle_exists(query["exists"]))
+
+    if "terms" in query:
+        for field, value in query["terms"].items():
+            terms.append(handle_terms(field, value))
+
+    if "term" in query:
+        for field, value in query["term"].items():
+            terms.append(handle_terms(field, value))
+
+    if "match" in query:
+        for field, value in query["match"].items():
+            terms.append(handle_match(field, value))
+
+    if len(terms) == 0:
+        raise ValueError("Not enough terms")
+    if len(terms) == 1:
+        return terms[0]
+    if len(terms) > 1:
+        return " AND ".join(map(b, terms))
+
+    # raise NotImplementedError(f'Unhandled keys {keys}')
+
+
+def handle_range(query):
+    statements = []
+    for field, inner in query.items():
+        op_map = {
+            "lt": "<",
+            "lte": "<=",
+            "gt": ">",
+            "gte": ">=",
+        }
+        for op in op_map:
+            if op in inner:
+                statements.append(f"{field} {op_map[op]} {inner[op]}")
+
+    if len(statements) > 1:
+        return " AND ".join(map(b, statements))
+    return statements[0]
+
+
+def handle_exists(exists):
+    field = exists["field"]
+    return f"{field} IS NOT NULL"
+
+
+def quote_value(value):
+    if isinstance(value, str):
+        escaped = value.replace("'", "\\'")
+        return f"'{escaped}'"
+    return value
+
+
+def handle_terms(field, value):
+    if isinstance(value, list):
+        prepped_values = ", ".join(map(quote_value, value))
+        return f"{field} in ({prepped_values})"
+
+    return f"{field}={quote_value(value)}"
+
+
+def handle_match(field, value):
+    return f"{field} like '%{value}%'"

--- a/translator/more-complex-query.json
+++ b/translator/more-complex-query.json
@@ -1,0 +1,269 @@
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must_not": [
+                    {
+                      "exists": {
+                        "field": "AF"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "range": {
+                  "AF": {
+                    "lte": 0.001
+                  }
+                }
+              }
+            ],
+            "must": [
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "exists": {
+                              "field": "exac_AF_POPMAX"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "range": {
+                        "exac_AF_POPMAX": {
+                          "lte": 0.0005
+                        }
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "exists": {
+                              "field": "g1k_POPMAX_AF"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "range": {
+                        "g1k_POPMAX_AF": {
+                          "lte": 0.0005
+                        }
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "exists": {
+                              "field": "gnomad_exomes_FAF_AF"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "range": {
+                        "gnomad_exomes_FAF_AF": {
+                          "lte": 0.0005
+                        }
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "exists": {
+                              "field": "gnomad_genomes_FAF_AF"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "range": {
+                        "gnomad_genomes_FAF_AF": {
+                          "lte": 0.0005
+                        }
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "exists": {
+                              "field": "sf"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "range": {
+                        "sf": {
+                          "lte": 0.001
+                        }
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "exists": {
+                              "field": "topmed_AF"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "range": {
+                        "topmed_AF": {
+                          "lte": 0.0005
+                        }
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "terms": {
+            "clinvar_clinical_significance": [
+              "Likely_pathogenic",
+              "Pathogenic",
+              "Pathogenic/Likely_pathogenic"
+            ]
+          }
+        },
+        {
+          "bool": {
+            "must": [
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "term": {
+                              "samples_no_call": "NA12891"
+                            }
+                          },
+                          {
+                            "term": {
+                              "samples_num_alt_2": "NA12891"
+                            }
+                          }
+                        ],
+                        "must": [
+                          {
+                            "term": {
+                              "samples_num_alt_2": "NA12878"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must": [
+                          {
+                            "match": {
+                              "contig": "X"
+                            }
+                          },
+                          {
+                            "term": {
+                              "samples_num_alt_2": "NA12878"
+                            }
+                          }
+                        ],
+                        "must_not": [
+                          {
+                            "term": {
+                              "samples_no_call": "NA12891"
+                            }
+                          },
+                          {
+                            "term": {
+                              "samples_num_alt_1": "NA12891"
+                            }
+                          },
+                          {
+                            "term": {
+                              "samples_num_alt_2": "NA12891"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "_name": "F000001_trio"
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    "xpos",
+    "variantId"
+  ],
+  "from": 0,
+  "size": 100
+}

--- a/translator/query_na12878.json
+++ b/translator/query_na12878.json
@@ -1,0 +1,177 @@
+{
+    "query": {
+        "bool": {
+            "filter": [
+                {
+                    "bool": {
+                        "should": [
+                            {
+                                "bool": {
+                                    "must_not": [
+                                        {
+                                            "exists": {
+                                                "field": "AF"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "range": {
+                                    "AF": {
+                                        "lte": 1
+                                    }
+                                }
+                            }
+                        ],
+                        "must": [
+                            {
+                                "bool": {
+                                    "should": [
+                                        {
+                                            "bool": {
+                                                "must_not": [
+                                                    {
+                                                        "exists": {
+                                                            "field": "topmed_AF"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "range": {
+                                                "topmed_AF": {
+                                                    "lte": 1
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "minimum_should_match": 1
+                                }
+                            }
+                        ],
+                        "minimum_should_match": 1
+                    }
+                },
+                {
+                    "bool": {
+                        "must": [
+                            {
+                                "bool": {
+                                    "must_not": [
+                                        {
+                                            "term": {
+                                                "samples_no_call": "NA12891"
+                                            }
+                                        },
+                                        {
+                                            "term": {
+                                                "samples_num_alt_2": "NA12891"
+                                            }
+                                        }
+                                    ],
+                                    "must": [
+                                        {
+                                            "term": {
+                                                "samples_num_alt_2": "NA12878"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "_name": "F000001_trio"
+                    }
+                }
+            ]
+        }
+    },
+    "sort": [
+        "xpos",
+        "variantId"
+    ],
+    "from": 0,
+    "size": 100,
+    "_source": [
+        "alt",
+        "contig",
+        "end",
+        "filters",
+        "num_exon",
+        "originalAltAlleles",
+        "ref",
+        "rsid",
+        "start",
+        "svType",
+        "variantId",
+        "xpos",
+        "rg37_locus",
+        "sv_type_detail",
+        "cpx_intervals",
+        "cadd_PHRED",
+        "dbnsfp_DANN_score",
+        "eigen_Eigen_phred",
+        "dbnsfp_FATHMM_pred",
+        "dbnsfp_GERP_RS",
+        "mpc_MPC",
+        "dbnsfp_MetaSVM_pred",
+        "dbnsfp_MutationTaster_pred",
+        "dbnsfp_phastCons100way_vertebrate",
+        "dbnsfp_Polyphen2_HVAR_pred",
+        "primate_ai_score",
+        "splice_ai_delta_score",
+        "splice_ai_splice_consequence",
+        "dbnsfp_REVEL_score",
+        "dbnsfp_SIFT_pred",
+        "StrVCTVRE_score",
+        "sortedTranscriptConsequences",
+        "genotypes",
+        "samples_num_alt_1",
+        "samples_num_alt_2",
+        "samples",
+        "clinvar_clinical_significance",
+        "clinvar_variation_id",
+        "clinvar_allele_id",
+        "clinvar_gold_stars",
+        "hgmd_accession",
+        "hgmd_class",
+        "sf",
+        "sc",
+        "sn",
+        "sv_callset_Hom",
+        "sv_callset_Hemi",
+        "sv_callset_Het",
+        "sv_callset_ID",
+        "AF",
+        "AC",
+        "AN",
+        "callset_Hom",
+        "callset_Hemi",
+        "callset_Het",
+        "callset_ID",
+        "topmed_AF",
+        "topmed_AC",
+        "topmed_AN",
+        "topmed_Hom",
+        "topmed_Hemi",
+        "topmed_Het",
+        "topmed_ID",
+        "g1k_POPMAX_AF",
+        "g1k_AF",
+        "g1k_AC",
+        "g1k_AN",
+        "g1k_Hom",
+        "g1k_Hemi",
+        "g1k_Het",
+        "g1k_ID",
+        "exac_AF_POPMAX",
+        "exac_AC_Adj",
+        "exac_AN_Adj",
+        "exac_AC_Hom",
+        "exac_AC_Hemi",
+        "exac_AF",
+        "exac_Het",
+        "exac_ID"
+    ]
+}


### PR DESCRIPTION
Test converting elasticsearch queries to the arrow protobuff format.

It seems to be approximately matching, I don't have any raw ES queries to compare to the hand-translated examples. There are some small differences, but it looks like it was hand-simplified to `is_null` where the translation is building `invert { is_valid { ... } }`.